### PR TITLE
Dev/local host version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ metals.sbt
 /.lib/
 
 
+
 # environment variables
 apikey.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,81 @@
+## generic files to ignore
+*~
+*.lock
+*.DS_Store
+*.swp
+*.out
+
+# rails specific
+*.sqlite3
+config/database.yml
+log/*
+tmp/*
+
+# java specific
+*.class
+
+# python specific
+*.pyc
+
+# xcode/iphone specific
+build/*
+*.pbxuser
+*.mode2v3
+*.mode1v3
+*.perspective
+*.perspectivev3
+*~.nib
+
+# akka specific
+logs/*
+
+# sbt specific
+target/
+project/boot
+lib_managed/*
+project/build/target
+project/build/lib_managed
+project/build/src_managed
+project/plugins/lib_managed
+project/plugins/target
+project/plugins/src_managed
+project/plugins/project
+
+core/lib_managed
+core/target
+pubsub/lib_managed
+pubsub/target
+
+.bsp/
+
+# eclipse specific
+.metadata
+jrebel.lic
+.settings
+.classpath
+.project
+
+.ensime*
+*.sublime-*
+.cache
+
+# intellij
+*.eml
+*.iml
+*.ipr
+*.iws
+.*.sw?
+.idea
+
+# metals
+.vscode/
+.metals/
+.bloop/
+metals.sbt
+
+# paulp script
+/.lib/
+
+
+# environment variables
+apikey.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:8
+
+ENV SBT_VERSION 1.7.2
+
+RUN curl -L -o sbt-$SBT_VERSION.zip https://github.com/sbt/sbt/releases/download/v1.7.2/sbt-$SBT_VERSION.zip
+RUN unzip sbt-$SBT_VERSION.zip -d ops
+
+WORKDIR /apikeyproxy
+
+COPY . /apikeyproxy
+
+EXPOSE 8080
+
+CMD /ops/sbt/bin/sbt jetty:start jetty:join

--- a/README.md
+++ b/README.md
@@ -19,5 +19,24 @@ For restart upon changing files:
 ```
 
 
+Using this software: Once the Jetty runner is running, send a POST request to http://localhost:8080/ containing JSON file with proper OpenAI-format, and wait for a moment to receive the answer.
+
+For example:
+
+```
+{
+    "model": "text-davinci-002",
+    "prompt": "List 10 science fiction books:",
+    "temperature": 0.5,
+    "max_tokens": 200,
+    "top_p": 1.0,
+    "frequency_penalty": 0.52,
+    "presence_penalty": 0.5,
+    "stop": [
+        "11."
+    ]
+}```
+
+
 Authors:
 Antti Halava (Bytecraft)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# APIKeyProxy #
+
+## Build & Run ##
+
+```sh
+$ cd apikeyproxy
+$ sbt
+> Jetty / start
+```
+
+If you want to quit:
+```
+> Jetty / stop
+```
+
+For restart upon changing files:
+```
+> ~Jetty / start
+```
+
+
+Authors:
+Antti Halava (Bytecraft)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # APIKeyProxy #
 
 ## Build & Run ##
@@ -22,7 +21,6 @@ For restart upon changing files:
 
 Using this software: Once the Jetty runner is running, send a POST request to http://localhost:8080/ containing JSON file with proper OpenAI-format, and wait for a moment to receive the answer.
 
-
 This requires that you have OpenAI Apikey in your environment variable, stored in "OpenAI_apikey". Include thea Bearer token (without the "Bearer", just the apikey).
 
 For example:
@@ -35,15 +33,9 @@ For example:
     "max_tokens": 200,
     "top_p": 1.0,
     "frequency_penalty": 0.52,
-    "presence_penalty": 0.5,
-    "stop": [
-        "11."
-    ]
-}```
-
+    "presence_penalty": 0.5
+}
+```
 
 Authors:
 Antti Halava (Bytecraft)
-=======
-# aalto-2022-proxy
->>>>>>> 9cae11927ba50f01ddfb0d2c212be61420f27417

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ For restart upon changing files:
 
 Using this software: Once the Jetty runner is running, send a POST request to http://localhost:8080/ containing JSON file with proper OpenAI-format, and wait for a moment to receive the answer.
 
+
+This requires that you have OpenAI Apikey in your environment variable, stored in "OpenAI_apikey". Include thea Bearer token (without the "Bearer", just the apikey).
+
 For example:
 
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,22 @@
+val ScalatraVersion = "2.8.2"
+
+ThisBuild / scalaVersion := "2.13.9"
+ThisBuild / organization := "fi.bytecraft"
+
+lazy val hello = (project in file("."))
+  .settings(
+    name := "APIKeyProxy",
+    version := "0.1.0-SNAPSHOT",
+    libraryDependencies ++= Seq(
+      "org.scalatra" %% "scalatra" % ScalatraVersion,
+      "org.scalatra" %% "scalatra-scalatest" % ScalatraVersion % "test",
+      "ch.qos.logback" % "logback-classic" % "1.2.3" % "runtime",
+      "org.eclipse.jetty" % "jetty-webapp" % "9.4.43.v20210629" % "container",
+      "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided",
+      "com.lihaoyi" %% "requests" % "0.7.1",
+      "com.lihaoyi" %% "upickle" % "1.6.0"
+    ),
+  )
+
+enablePlugins(SbtTwirl)
+enablePlugins(JettyPlugin)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.1")
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.4")

--- a/promptSchema.json
+++ b/promptSchema.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "prompt": {
+        "type": "string"
+      },
+      "max_tokens": {
+        "type": "integer"
+      },
+      "temperature": {
+        "type": "integer"
+      },
+      "top_p": {
+        "type": "integer"
+      },
+      "n": {
+        "type": "integer"
+      },
+      "stream": {
+        "type": "boolean"
+      },
+      "logprobs": {
+        "type": "null"
+      },
+      "stop": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "model",
+      "prompt",
+      "max_tokens",
+      "temperature",
+      "top_p",
+      "n",
+      "stream",
+      "logprobs",
+      "stop"
+    ]
+  }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -1,0 +1,9 @@
+import fi.bytecraft.proxy._
+import org.scalatra._
+import javax.servlet.ServletContext
+
+class ScalatraBootstrap extends LifeCycle {
+  override def init(context: ServletContext) {
+    context.mount(new APIKeyProxyServlet, "/*")
+  }
+}

--- a/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
+++ b/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
@@ -10,8 +10,6 @@ class APIKeyProxyServlet extends ScalatraServlet {
     val apiKey: String = "Bearer " + sys.env.get("OpenAI_apikey").getOrElse("Apikey not received from environment variable.")
     val timeout: Int = 10000
 
-    println("Apikey: " + sys.env.get("OpenAI_apikey"))
-
     val r = requests.post(
        "https://api.openai.com/v1/completions",
        data = promptJson,

--- a/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
+++ b/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
@@ -7,8 +7,10 @@ class APIKeyProxyServlet extends ScalatraServlet {
 
   post("/") {
     val promptJson: String = request.body
-    val apiKey: String = Source.fromFile("apikey.txt").getLines.mkString
+    val apiKey: String = sys.env.get("OpenAI_apikey").getOrElse("Apikey not received from environment variable.")
     val timeout: Int = 10000
+
+    println("Apikey: " + sys.env)
 
     val r = requests.post(
        "https://api.openai.com/v1/completions",

--- a/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
+++ b/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
@@ -1,0 +1,22 @@
+package fi.bytecraft.proxy
+
+import org.scalatra._
+import scala.io.Source
+
+class APIKeyProxyServlet extends ScalatraServlet {
+
+  post("/") {
+    val promptJson: String = request.body
+    val apiKey: String = Source.fromFile("apikey.txt").getLines.mkString
+    val timeout: Int = 10000
+
+    val r = requests.post(
+       "https://api.openai.com/v1/completions",
+       data = promptJson,
+       headers = Map("Authorization" -> apiKey, "Content-Type" -> "application/json"),
+       readTimeout = timeout
+    )
+
+    r.text
+  }
+}

--- a/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
+++ b/src/main/scala/fi/bytecraft/proxy/APIKeyProxyServlet.scala
@@ -7,10 +7,10 @@ class APIKeyProxyServlet extends ScalatraServlet {
 
   post("/") {
     val promptJson: String = request.body
-    val apiKey: String = sys.env.get("OpenAI_apikey").getOrElse("Apikey not received from environment variable.")
+    val apiKey: String = "Bearer " + sys.env.get("OpenAI_apikey").getOrElse("Apikey not received from environment variable.")
     val timeout: Int = 10000
 
-    println("Apikey: " + sys.env)
+    println("Apikey: " + sys.env.get("OpenAI_apikey"))
 
     val r = requests.post(
        "https://api.openai.com/v1/completions",

--- a/src/main/twirl/layouts/default.scala.html
+++ b/src/main/twirl/layouts/default.scala.html
@@ -1,0 +1,10 @@
+@(title: String, headline: String)(body: Html)
+<html>
+  <head>
+    <title>@title</title>
+  </head>
+  <body>
+    <h1>@headline</h1>
+    @body
+  </body>
+</html>

--- a/src/main/twirl/views/hello.scala.html
+++ b/src/main/twirl/views/hello.scala.html
@@ -1,0 +1,4 @@
+@()
+@layouts.html.default("Scalatra: a tiny, Sinatra-like web framework for Scala", "Welcome to Scalatra"){
+  <p>Hello, Twirl!</p>
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+  http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+  version="3.1">
+
+  <!--
+    This listener loads a class in the default package called ScalatraBootstrap.
+    That class should implement org.scalatra.LifeCycle.  Your app can be
+    configured in Scala code there.
+  -->
+  <listener>
+    <listener-class>org.scalatra.servlet.ScalatraListener</listener-class>
+  </listener>
+</web-app>

--- a/src/test/scala/fi/bytecraft/proxy/APIKeyProxyServletTests.scala
+++ b/src/test/scala/fi/bytecraft/proxy/APIKeyProxyServletTests.scala
@@ -1,0 +1,9 @@
+package fi.bytecraft.proxy
+
+import org.scalatra.test.scalatest._
+
+class APIKeyProxyServletTests extends ScalatraFunSuite {
+
+  addServlet(classOf[APIKeyProxyServlet], "/*")
+
+}


### PR DESCRIPTION
Working localhost version, instructions for use can be found in the Readme file. 

The solution will route a request sent to the root via POST-call and add the apikey to the request and send it to OpenAI API-endpoint.


The solution uses https://scalatra.org/ Scalatra micro-framework and requires JDK and SBT https://scalatra.org/getting-started/installation.html

Note: You need to have your Bearer apikey in environment variable "OpenAI_apikey"


The Dockerfile is not yet tested (just a possible image chosen), and the current Dockerfile is likely a bad solution as it includes the build tool.