### PR TITLE
Build and deploy proxy to server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           name: proxy_docker_image
           path: /tmp/proxy_docker_image.tar
+          retention-days: 7
 
   deploy:
     environment: main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,65 @@
+name: ci
+
+on:
+  # Run on all branches
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: aalto_2022_proxy:latest
+          outputs: type=docker,dest=/tmp/proxy_docker_image.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: proxy_docker_image
+          path: /tmp/proxy_docker_image.tar
+
+  deploy:
+    environment: main
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: proxy_docker_image
+          path: /tmp
+
+      - name: Load image
+        run: |
+          docker load --input /tmp/proxy_docker_image.tar
+
+      - name: Add SSH key
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: mkdir -p ~/.ssh && printf "%s" "$SSH_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+
+      - name: Add host to known_hosts
+        run: echo "|1|51Fg/gQzqNfhMkuBnxLBSWCrl+s=|TbUOHEmNxVDTGdkxvvlmlN761QM= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMV0unNHDl5cqDEDYe5ADTCgXMZxr02k5M4mcI9gFPtlrUiDjlE0UTZ8ejgPWhILtK3iETzNb8FD53dMn6Ck/vQ=" >> ~/.ssh/known_hosts
+
+      - name: Stop proxy service
+        run: ssh root@65.108.249.101 "systemctl stop aalto_2022_proxy.service"
+
+      - name: Push image to server
+        run: |
+          docker save aalto_2022_proxy:latest | ssh -C root@65.108.249.101 docker load
+
+      - name: Start proxy service
+        run: ssh root@65.108.249.101 "systemctl start aalto_2022_proxy.service"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
           retention-days: 7
 
   deploy:
-    environment: main
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     needs: build
-    runs-on: ubuntu-latest
+    environment: main
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -63,4 +63,4 @@ jobs:
           docker save aalto_2022_proxy:latest | ssh -C root@65.108.249.101 docker load
 
       - name: Start proxy service
-        run: ssh root@65.108.249.101 "systemctl start aalto_2022_proxy.service"
+        run: ssh root@65.108.249.101 "systemctl enable --now aalto_2022_proxy.service"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,12 +55,9 @@ jobs:
       - name: Add host to known_hosts
         run: echo "|1|51Fg/gQzqNfhMkuBnxLBSWCrl+s=|TbUOHEmNxVDTGdkxvvlmlN761QM= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMV0unNHDl5cqDEDYe5ADTCgXMZxr02k5M4mcI9gFPtlrUiDjlE0UTZ8ejgPWhILtK3iETzNb8FD53dMn6Ck/vQ=" >> ~/.ssh/known_hosts
 
-      - name: Stop proxy service
-        run: ssh root@65.108.249.101 "systemctl stop aalto_2022_proxy.service"
-
       - name: Push image to server
         run: |
           docker save aalto_2022_proxy:latest | ssh -C root@65.108.249.101 docker load
 
-      - name: Start proxy service
-        run: ssh root@65.108.249.101 "systemctl enable --now aalto_2022_proxy.service"
+      - name: Restart proxy service
+        run: ssh root@65.108.249.101 "systemctl enable aalto_2022_proxy.service && systemctl restart aalto_2022_proxy.service"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM docker.io/openjdk:8
 
 ENV SBT_VERSION 1.7.2
 


### PR DESCRIPTION
Requires https://github.com/bytecraftoy/aalto-2022-infra/pull/10 to be merged first

Builds the Docker image in Actions, sends it to the server through ssh and enables&starts the systemd service.