### PR TITLE
Dockefile: Upgrade openjdk version to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM docker.io/openjdk:8
+FROM docker.io/eclipse-temurin:17-jammy
 
 ENV SBT_VERSION 1.7.2
 
-RUN curl -L -o sbt-$SBT_VERSION.zip https://github.com/sbt/sbt/releases/download/v1.7.2/sbt-$SBT_VERSION.zip \
-    && unzip sbt-$SBT_VERSION.zip -d ops
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y unzip=6.0-26ubuntu3.1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -L -o sbt-$SBT_VERSION.zip https://github.com/sbt/sbt/releases/download/v1.7.2/sbt-$SBT_VERSION.zip && \
+    unzip sbt-$SBT_VERSION.zip -d ops
 
 WORKDIR /apikeyproxy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM docker.io/openjdk:8
 
 ENV SBT_VERSION 1.7.2
 
-RUN curl -L -o sbt-$SBT_VERSION.zip https://github.com/sbt/sbt/releases/download/v1.7.2/sbt-$SBT_VERSION.zip
-RUN unzip sbt-$SBT_VERSION.zip -d ops
+RUN curl -L -o sbt-$SBT_VERSION.zip https://github.com/sbt/sbt/releases/download/v1.7.2/sbt-$SBT_VERSION.zip \
+    && unzip sbt-$SBT_VERSION.zip -d ops
 
 WORKDIR /apikeyproxy
 
@@ -11,4 +11,4 @@ COPY . /apikeyproxy
 
 EXPOSE 8080
 
-CMD /ops/sbt/bin/sbt jetty:start jetty:join
+CMD ["/ops/sbt/bin/sbt", "jetty:start", "jetty:join"]


### PR DESCRIPTION
openjdk docker images are deprecated: https://hub.docker.com/_/openjdk

The maintainers main recommendations as replacement are either Amazon Corretto (https://hub.docker.com/_/amazoncorretto) or Eclipse Temurin (https://hub.docker.com/_/eclipse-temurin).

The Amazon image contains custom openjdk patches for Amazon internal services, but the Temurin by https://adoptium.net/ seems to be non-opinionated. 17 is the latest LTS version of Java. The image postfix -jammy targets 22.04 LTS version of Ubuntu.