### PR TITLE
Increase openai client timeout to 30 seconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func post(c *gin.Context) {
 	log.Info().Bytes("request_body", body).Msg("request_body")
 
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 
 	req, err := http.NewRequest("POST", "https://api.openai.com/v1/completions", bytes.NewBuffer(body))


### PR DESCRIPTION
high best_of sometimes lasts more than 10 seconds
